### PR TITLE
Fix compact header layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,6 +196,12 @@
             flex: 0 0 auto;
             position: relative;
         }
+
+        /* Ensure compact headers keep title and hamburger on one line */
+        .column-header.compact {
+            flex-wrap: nowrap;
+            justify-content: space-between;
+        }
         
         /* Force toolbar to wrap on smaller screens */
         @media (max-width: 500px) {


### PR DESCRIPTION
## Summary
- ensure column headers with the `compact` class keep the title and hamburger button on a single line

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6844c221f4a08327b9a16c8757841e1a