### PR TITLE
Add JSON import and localStorage autosave

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,9 @@
         </div>
         <button class="btn btn--neutral" id="toggle-layout-btn" data-tooltip="Toggle Layout">⫼</button>
         <button class="btn btn--primary" id="export-btn" data-tooltip="Export Document">↓</button>
+        <button class="btn btn--primary" id="load-btn" data-tooltip="Load Document">↑</button>
+        <input type="file" id="load-input" accept="application/json" style="display:none">
+        <button class="btn btn--secondary" id="clear-local-btn" data-tooltip="Clear Local Save">✕</button>
     </div>
 
     <div class="workspace">


### PR DESCRIPTION
## Summary
- add Load button, hidden file input, and Clear Local Save to UI
- cache new DOM elements in `init`
- implement full state save/load helpers and validation
- autosave to localStorage after every change
- load from localStorage on startup
- support manual JSON import and clearing local save

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6844ce61c0c08327a27c9fe4851117ac