### PR TITLE
Add header theming variables

### DIFF
--- a/style.css
+++ b/style.css
@@ -3,6 +3,8 @@
     --clr-secondary: #333;
     --bg-dark: #1a1a1a;
     --bg-header: #2a2a2a;
+    --header-bg: var(--bg-header);
+    --header-border: var(--clr-secondary);
     --bdr: #444;
     --btn-bg: #3a3a3a;
     --btn-hover: #4a4a4a;
@@ -21,6 +23,21 @@
     --btn-size: 48px;
     --toolbar-btn: 36px;
     --status-h: 22px;
+}
+
+body[data-theme="blue"] {
+    --header-bg: #0075c4;
+    --header-border: #005b99;
+}
+
+body[data-theme="orange"] {
+    --header-bg: #d76b00;
+    --header-border: #a85400;
+}
+
+body[data-theme="green"] {
+    --header-bg: #2e7d32;
+    --header-border: #1b5e20;
 }
 
 * { box-sizing: border-box; }
@@ -43,8 +60,8 @@ body, html {
     display: flex;
     align-items: center;
     padding: 8px 10px;
-    background: var(--bg-header);
-    border-bottom: 1px solid var(--clr-secondary);
+    background: var(--header-bg);
+    border-bottom: 1px solid var(--header-border);
     gap: 8px;
 }
 


### PR DESCRIPTION
## Summary
- theme the header separately with --header-bg and --header-border
- support color themes for blue, orange, and green

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844d6359b708327aa5b95f8470620a8