### PR TITLE
Add column fullscreen toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,11 @@
                             <path fill-rule="evenodd" d="M1.323 11.447C2.811 6.976 7.028 3.75 12.001 3.75c4.97 0 9.185 3.223 10.675 7.69.12.362.12.752 0 1.113-1.487 4.471-5.705 7.697-10.677 7.697-4.97 0-9.186-3.223-10.675-7.69a1.762 1.762 0 0 1 0-1.113ZM17.25 12a5.25 5.25 0 1 1-10.5 0 5.25 5.25 0 0 1 10.5 0Z" clip-rule="evenodd" />
                         </svg>
                     </button>
+                    <button data-action="fullscreen" data-pane="left" data-tooltip="Fullscreen">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="icon size-6">
+                          <path fill-rule="evenodd" d="M15 3.75a.75.75 0 0 1 .75-.75h4.5a.75.75 0 0 1 .75.75v4.5a.75.75 0 0 1-1.5 0V5.56l-3.97 3.97a.75.75 0 1 1-1.06-1.06l3.97-3.97h-2.69a.75.75 0 0 1-.75-.75Zm-12 0A.75.75 0 0 1 3.75 3h4.5a.75.75 0 0 1 0 1.5H5.56l3.97 3.97a.75.75 0 0 1-1.06 1.06L4.5 5.56v2.69a.75.75 0 0 1-1.5 0v-4.5Zm11.47 11.78a.75.75 0 1 1 1.06-1.06l3.97 3.97v-2.69a.75.75 0 0 1 1.5 0v4.5a.75.75 0 0 1-.75.75h-4.5a.75.75 0 0 1 0-1.5h2.69l-3.97-3.97Zm-4.94-1.06a.75.75 0 0 1 0 1.06L5.56 19.5h2.69a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1-.75-.75v-4.5a.75.75 0 0 1 1.5 0v2.69l3.97-3.97a.75.75 0 0 1 1.06 0Z" clip-rule="evenodd" />
+                        </svg>
+                    </button>
                     <button class="menu-toggle" data-pane="left" data-tooltip="Menu" aria-expanded="false" aria-haspopup="true" aria-controls="left-dropdown">
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="icon">
                             <path fill-rule="evenodd" d="M10.5 6a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0Zm0 6a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0Zm0 6a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0Z" clip-rule="evenodd" />
@@ -148,6 +153,11 @@ blocks
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="icon">
                             <path d="M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z" />
                             <path fill-rule="evenodd" d="M1.323 11.447C2.811 6.976 7.028 3.75 12.001 3.75c4.97 0 9.185 3.223 10.675 7.69.12.362.12.752 0 1.113-1.487 4.471-5.705 7.697-10.677 7.697-4.97 0-9.186-3.223-10.675-7.69a1.762 1.762 0 0 1 0-1.113ZM17.25 12a5.25 5.25 0 1 1-10.5 0 5.25 5.25 0 0 1 10.5 0Z" clip-rule="evenodd" />
+                        </svg>
+                    </button>
+                    <button data-action="fullscreen" data-pane="right" data-tooltip="Fullscreen">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="icon size-6">
+                          <path fill-rule="evenodd" d="M15 3.75a.75.75 0 0 1 .75-.75h4.5a.75.75 0 0 1 .75.75v4.5a.75.75 0 0 1-1.5 0V5.56l-3.97 3.97a.75.75 0 1 1-1.06-1.06l3.97-3.97h-2.69a.75.75 0 0 1-.75-.75Zm-12 0A.75.75 0 0 1 3.75 3h4.5a.75.75 0 0 1 0 1.5H5.56l3.97 3.97a.75.75 0 0 1-1.06 1.06L4.5 5.56v2.69a.75.75 0 0 1-1.5 0v-4.5Zm11.47 11.78a.75.75 0 1 1 1.06-1.06l3.97 3.97v-2.69a.75.75 0 0 1 1.5 0v4.5a.75.75 0 0 1-.75.75h-4.5a.75.75 0 0 1 0-1.5h2.69l-3.97-3.97Zm-4.94-1.06a.75.75 0 0 1 0 1.06L5.56 19.5h2.69a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1-.75-.75v-4.5a.75.75 0 0 1 1.5 0v2.69l3.97-3.97a.75.75 0 0 1 1.06 0Z" clip-rule="evenodd" />
                         </svg>
                     </button>
                     <button class="menu-toggle" data-pane="right" data-tooltip="Menu" aria-expanded="false" aria-haspopup="true" aria-controls="right-dropdown">

--- a/script.js
+++ b/script.js
@@ -145,6 +145,21 @@ const ac = {
             b.innerHTML = md ? icons.viewText : icons.viewMd;
         }
         md && rn(p);
+    },
+    fullscreen: (p, b) => {
+        const pane = p === 'l' ? e.lp : e.rp;
+        const other = p === 'l' ? e.rp : e.lp;
+        const isFullscreen = pane.classList.toggle('fullscreen');
+
+        if (isFullscreen) {
+            other.style.display = 'none';
+            e.sp.style.display = 'none';
+            b.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="icon size-6"><path fill-rule="evenodd" d="M3.22 3.22a.75.75 0 0 1 1.06 0l3.97 3.97V4.5a.75.75 0 0 1 1.5 0V9a.75.75 0 0 1-.75.75H4.5a.75.75 0 0 1 0-1.5h2.69L3.22 4.28a.75.75 0 0 1 0-1.06Zm17.56 0a.75.75 0 0 1 0 1.06l-3.97 3.97h2.69a.75.75 0 0 1 0 1.5H15a.75.75 0 0 1-.75-.75V4.5a.75.75 0 0 1 1.5 0v2.69l3.97-3.97a.75.75 0 0 1 1.06 0ZM3.75 15a.75.75 0 0 1 .75-.75H9a.75.75 0 0 1 .75.75v4.5a.75.75 0 0 1-1.5 0v-2.69l-3.97 3.97a.75.75 0 0 1-1.06-1.06l3.97-3.97H4.5a.75.75 0 0 1-.75-.75Zm10.5 0a.75.75 0 0 1 .75-.75h4.5a.75.75 0 0 1 0 1.5h-2.69l3.97 3.97a.75.75 0 1 1-1.06 1.06l-3.97-3.97v2.69a.75.75 0 0 1-1.5 0V15Z" clip-rule="evenodd"/></svg>';
+        } else {
+            other.style.display = '';
+            e.sp.style.display = '';
+            b.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="icon size-6"><path fill-rule="evenodd" d="M15 3.75a.75.75 0 0 1 .75-.75h4.5a.75.75 0 0 1 .75.75v4.5a.75.75 0 0 1-1.5 0V5.56l-3.97 3.97a.75.75 0 1 1-1.06-1.06l3.97-3.97h-2.69a.75.75 0 0 1-.75-.75Zm-12 0A.75.75 0 0 1 3.75 3h4.5a.75.75 0 0 1 0 1.5H5.56l3.97 3.97a.75.75 0 0 1-1.06 1.06L4.5 5.56v2.69a.75.75 0 0 1-1.5 0v-4.5Zm11.47 11.78a.75.75 0 1 1 1.06-1.06l3.97 3.97v-2.69a.75.75 0 0 1 1.5 0v4.5a.75.75 0 0 1-.75.75h-4.5a.75.75 0 0 1 0-1.5h2.69l-3.97-3.97Zm-4.94-1.06a.75.75 0 0 1 0 1.06L5.56 19.5h2.69a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1-.75-.75v-4.5a.75.75 0 0 1 1.5 0v2.69l3.97-3.97a.75.75 0 0 1 1.06 0Z" clip-rule="evenodd"/></svg>';
+        }
     }
 };
 

--- a/style.css
+++ b/style.css
@@ -55,11 +55,16 @@ body, html {
 .main-title input {
     width: 100%;
     padding: 6px 8px;
-    background: var(--bg-dark);
-    border: 1px solid var(--bdr);
+    background: transparent;
+    border: none;
     border-radius: 4px;
     color: var(--clr-primary);
     font-size: 14px;
+    outline: none;
+}
+.main-title input:focus {
+    border: 1px solid var(--bdr);
+    background: var(--bg-dark);
 }
 
 .btn {
@@ -122,6 +127,13 @@ body, html {
     min-height: min(200px, 30vh);
 }
 
+.pane.fullscreen {
+    flex: 1 1 100% !important;
+    width: 100% !important;
+    height: 100% !important;
+    z-index: 10;
+}
+
 
 .pane[data-accent="blue"] {
     --accent: var(--blue);
@@ -180,7 +192,7 @@ body, html {
 }
 
 .column-title {
-    flex: 1 1 auto;
+    flex: 0 1 70%;
     min-width: 0;
 }
 
@@ -188,10 +200,15 @@ body, html {
     width: 100%;
     padding: 4px 6px;
     background: transparent;
-    border: 1px solid var(--bdr);
+    border: none;
     border-radius: 3px;
     color: var(--clr-primary);
     font-size: 12px;
+    outline: none;
+}
+.column-title input:focus {
+    border: 1px solid var(--bdr);
+    background: var(--bg-dark);
 }
 
 .toolbar {
@@ -486,5 +503,10 @@ textarea::placeholder {
     height: 16px;
     margin-right: 6px;
     vertical-align: middle;
+}
+
+.size-6 {
+    width: 24px;
+    height: 24px;
 }
 


### PR DESCRIPTION
## Summary
- add fullscreen buttons to column toolbars
- implement fullscreen logic and toggle SVG icon
- style fullscreen pane
- fix button event handling by adding icon class and css sizing
- tweak column title width and borders

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d98bc2e48327982e545a1516a2ee