### PR TITLE
Fix column header title overflow

### DIFF
--- a/style.css
+++ b/style.css
@@ -210,8 +210,6 @@ body, html {
 
 .column-title {
     flex: 1 1 auto;
-    max-width: 70%;
-    flex: 0 1 70%;
     min-width: 0;
 }
 


### PR DESCRIPTION
## Summary
- adjust column title flex sizing so toolbar stays on a single line

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6844e18cc6648327b51d8a3ace409031