### PR TITLE
Fix column header width handling

### DIFF
--- a/style.css
+++ b/style.css
@@ -209,9 +209,7 @@ body, html {
 }
 
 .column-title {
-    flex: 1 1 auto;
-    max-width: 70%;
-    flex: 0 1 70%;
+    flex: 1 1 0;
     min-width: 0;
 }
 


### PR DESCRIPTION
## Summary
- tune column title flex-basis to avoid overflow

## Testing
- `npm install --silent`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6844e18cc6648327b51d8a3ace409031