### PR TITLE
Remove unused pane accent function

### DIFF
--- a/script.js
+++ b/script.js
@@ -63,15 +63,6 @@ const th = f => {
     };
 };
 
-// Change pane accent color
-function setPaneAccent(paneElement, accentName) {
-    paneElement.classList.forEach(c => {
-        if (c.startsWith('accent-')) paneElement.classList.remove(c);
-    });
-    paneElement.classList.add(`accent-${accentName}`);
-    paneElement.setAttribute('data-accent', accentName);
-}
-
 // Save state
 function sv(p) {
     const c = e[p].e.value, h = s[p];


### PR DESCRIPTION
## Summary
- clean up script.js by deleting the unused `setPaneAccent` helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844e71a95a48327bee70b0a6d60fcf4