### PR TITLE
Trim meta title in getState

### DIFF
--- a/script.js
+++ b/script.js
@@ -176,7 +176,7 @@ function getState(d = new Date()) {
     const v = e.ws.classList.contains('vertical');
     return {
         meta: {
-            title: e.mt.value || 'document',
+            title: (e.mt.value || '').trim() || 'document',
             created: d.toISOString(),
             exported: d.toISOString(),
             layout: v ? 'vertical' : 'horizontal'


### PR DESCRIPTION
## Summary
- trim whitespace in `getState()` when setting meta title
- ensure export filenames continue to use sanitized titles
- run tests

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844e7193dd8832781928b8782fd817e