### PR TITLE
Fix applyState history init

### DIFF
--- a/script.js
+++ b/script.js
@@ -226,8 +226,8 @@ function applyState(d) {
     }
 
     ['l','r'].forEach(p => {
-        const val = e[p].e.value;
-        s[p] = { h: [val], i: 0, c: val };
+        s[p] = { h: [], i: -1, c: '' };
+        sv(p);
     });
 
     rn('l');


### PR DESCRIPTION
## Summary
- initialize pane history as empty when applying state
- push the first history entry for each pane

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844e71936f48327a538813a05903622